### PR TITLE
Update for compatibility with Linux 5.1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ PLATFORM = PC
 
 MAKE = make
 
-LINUX_SRC = /lib/modules/$(shell uname -r)/build
-LINUX_SRC_MODULE = /lib/modules/$(shell uname -r)/kernel/drivers/net/wireless/
+KERNELRELEASE = $(shell uname -r)
+LINUX_SRC = /lib/modules/$(KERNELRELEASE)/build
+LINUX_SRC_MODULE = /lib/modules/$(KERNELRELEASE)/kernel/drivers/net/wireless/
 CROSS_COMPILE =
 
 export OSABL RT28xx_DIR RT28xx_MODE LINUX_SRC CROSS_COMPILE CROSS_COMPILE_INCLUDE PLATFORM RELEASE CHIPSET MODULE RTMP_SRC_DIR LINUX_SRC_MODULE TARGET HAS_WOW_SUPPORT

--- a/os/linux/rt_linux.c
+++ b/os/linux/rt_linux.c
@@ -672,7 +672,7 @@ RTMP_OS_FD RtmpOSFileOpen(char *pPath, int flag, int mode)
 		flag = O_TRUNC;
 
 	oldfs = get_fs();
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 	filePtr = filp_open(pPath, flag, 0);
 	set_fs(oldfs);
 
@@ -704,7 +704,7 @@ int RtmpOSFileRead(RTMP_OS_FD osfd, char *pDataPtr, int readLen)
 	int ret;
 	mm_segment_t fs = get_fs();
 
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 	ret = kernel_read(osfd, pDataPtr, readLen, &osfd->f_pos);
@@ -722,7 +722,7 @@ int RtmpOSFileWrite(RTMP_OS_FD osfd, char *pDataPtr, int writeLen)
 	int ret;
 	mm_segment_t oldfs = get_fs();
 
-	set_fs(get_ds());
+	set_fs(KERNEL_DS);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14, 0)
 	ret = kernel_write(osfd, pDataPtr, writeLen, &osfd->f_pos);


### PR DESCRIPTION
This makes the code compile on 5.1.8. However, loading the module still generates a kernel oops due to a read fault in `CFG80211_SupBandInit.cold.1+0x2b/0x6f`